### PR TITLE
9 cleanup - removed fast surface processing option

### DIFF
--- a/batches/cat12_postmortem.m
+++ b/batches/cat12_postmortem.m
@@ -25,9 +25,8 @@
 % * Start SPM/CAT with: 
 %   spm 'fmri'; cat12('developer')
 % * Specify your own directories below 
-% * Update some variables such as "resolution", "spm_res_factor" and
-%   "preview_surfaces" that are defined for a fast test run
-%   (currently it is only reducing resolution with preview surface estimation)
+% * Update some variables such as "resolution" and "spm_res_factor" that 
+%   are defined for a fast test run
 % * Open the SPM batch mode via SPM GUI
 % * Open this batch in the SPM batch mode 
 % * Start the batch (if it is not ready or create errors then start 
@@ -126,8 +125,7 @@ tol                = 1e-32;  % super accurate to correct even strong inhomogenei
 %spm_res_factor     = 1.5/resolution;    % use x-times lower sampling resolution (depending on the resolution variable) for SPM for faster tests 
                            % for a resolution of 0.8 and spm_res_factor of 2 SPM will use 1.6 mm (default is 3 mm for human data and)                            
 nproc              = 0;    % number of parallel processes of the CAT preprocessing
-preview_surfaces   = 5;    % (0 - none, 1 - yes, 5 - fast preview surfaces for visual checks but not for statistical analyses
-                           % use 5 for fast reviews to optimize the pipeline 
+surfaces           = 1;    % (0 - none, 1 - yes)
 reduce_mesh        = 5;    % more accurate but maybe with fatal Matlab crash (just try to rerun) otherwise use 1 (optimal by volume reduction)
 %ngaus              = [1 1 2 3];  % [GM WM CSF[/BG | BG]] ... [2 1 3 4] seems also to work
 ngaus              = [2 1 3 4];  % [GM WM CSF[/BG | BG]] ... [2 1 3 4] seems also to work
@@ -555,7 +553,7 @@ matlabbatch{mi}.spm.tools.cat.estwrite_spm.extopts.admin.verb               = 2;
 matlabbatch{mi}.spm.tools.cat.estwrite_spm.extopts.admin.print              = 2;
 % ############ Use this part to define the output of both CAT preprocessings ############## 
 matlabbatch{mi}.spm.tools.cat.estwrite_spm.output.BIDS.BIDSno               = 1;
-matlabbatch{mi}.spm.tools.cat.estwrite_spm.output.surface                   = preview_surfaces;
+matlabbatch{mi}.spm.tools.cat.estwrite_spm.output.surface                   = surfaces;
 matlabbatch{mi}.spm.tools.cat.estwrite_spm.output.ROImenu.atlases.neuromorphometrics = 1;
 matlabbatch{mi}.spm.tools.cat.estwrite_spm.output.ROImenu.atlases.lpba40             = 0;
 matlabbatch{mi}.spm.tools.cat.estwrite_spm.output.ROImenu.atlases.cobra              = 1;

--- a/cat_conf_output.m
+++ b/cat_conf_output.m
@@ -66,25 +66,21 @@ function [output,output_spm] = cat_conf_output(expert)
   surface        = cfg_menu;
   surface.tag    = 'surface';
   surface.name   = 'Surface and thickness estimation';
-  surface.labels = {'No','Yes','For visual preview only'};
-  surface.values = {0 1 5};
+  surface.labels = {'No','Yes'};
+  surface.values = {0 1};
   surface.def    = @(val)cat_get_defaults('output.surface', val{:});
   surface.help   = {
   'Use projection-based thickness (PBT) (Dahnke et al. 2012) to estimate cortical thickness and to create the central cortical surface for left and right hemisphere. Surface reconstruction includes topology correction (Yotter et al. 2011), spherical inflation (Yotter et al.) and spherical registration. Additionally you can also estimate surface parameters such as gyrification, cortical complexity or sulcal depth that can be subsequently analyzed at each vertex of the surface. '
   ''
   'Please note, that surface reconstruction and spherical registration additionally requires about 20-60 min of computation time.'
   ''
-  'A fast (1-3 min) surface pipeline is available for visual preview (e.g., to check preprocessing quality) in the cross-sectional, but not in the longitudinal pipeline.  Only the initial surfaces are created with a lower resolution and without topology correction, spherical mapping and surface registration.  Please note that the files with the estimated surface thickness can therefore not be used for further analysis!  For distinction, these files contain "preview" in their filename and they are not available as batch dependencies objects. '
-  ''
   };
 
   if expert == 2
-    surface.labels = {'No','lh + rh','lh + rh + cb',...
-      'lh + rh (preview)','lh + rh + cb (preview)', ...
-      ...'lh + rh (fast registration)', ... 7
-      'lh + rh + cb (fast registration)',... 8 
-      'Thickness estimation (for ROI analysis only)', 'Full'};
-    surface.values = {0 1 2 , 5 6 , 8 , 9 12}; % 7 8 
+    surface.labels = {'No', 'lh + rh (T1w-based)',  'lh + rh + cb (T1w-based)',...
+                            'lh + rh (AMAP-based)', 'lh + rh + cb (AMAP-based)',...
+                            'Thickness estimation (for ROI analysis only)', 'Full'};
+    surface.values = {0 1 2 , 11 12, 9 22}; 
     surface.help   = [surface.help; {
       'Cerebellar reconstruction is still in development and is strongly limited due to the high frequency of folding and image properties! '
       ''

--- a/cat_main.m
+++ b/cat_main.m
@@ -748,12 +748,14 @@ if ~debug, clear Yp0; end
 
 %% surface creation and thickness estimation
 %  ---------------------------------------------------------------------
-if all( [job.output.surface>0 job.output.surface<9 ] ) || (job.output.surface==9 && ...
+if all( [job.output.surface>0  job.output.surface<9  ] ) || ...
+   all( [job.output.surface>10 job.output.surface<19 ] ) ||  (job.output.surface==9 && ...
    any( [job.output.ct.native job.output.ct.warped job.output.ct.dartel job.output.ROI] ))
   
   % prepare some parameter
+  if ~isfield(job,'useprior'), job.useprior = ''; end
   Yp0 = zeros(d,'single'); Yp0(indx,indy,indz) = single(Yp0b)*5/255; 
-  [Ymix,job,surf,WMT] = cat_main_surf_preppara(Ymi,Yp0,job,vx_vol);
+  [Ymix,job,surf,stime] = cat_main_surf_preppara(Ymi,Yp0,job,vx_vol);
   
   %% default surface reconstruction 
   %  sum(Yth1(Yth1(:)>median(Yth1(Yth1(:)>0))*2 ))./sum(Yth1(Yth1(:)>0)) > 0.1 > error
@@ -800,7 +802,7 @@ if all( [job.output.surface>0 job.output.surface<9 ] ) || (job.output.surface==9
         'interpV',job.extopts.pbtres,'pbtmethod',job.extopts.pbtmethod,'SRP',mod(job.extopts.SRP,10),...
         'scale_cortex', job.extopts.scale_cortex, 'add_parahipp', job.extopts.add_parahipp, 'close_parahipp', job.extopts.close_parahipp,  ....
         'Affine',res.Affine,'surf',{surf},'pbtlas',job.extopts.pbtlas, ... % pbtlas is the new parameter to reduce myelination effects
-        'inv_weighting',job.inv_weighting,'verb',job.extopts.verb,'WMT',WMT,'useprior',job.useprior),job); 
+        'inv_weighting',job.inv_weighting,'verb',job.extopts.verb,'useprior',job.useprior),job); 
     end
   else
     %% createCS1 pipeline 
@@ -808,7 +810,7 @@ if all( [job.output.surface>0 job.output.surface<9 ] ) || (job.output.surface==9
       cat_surf_createCS(VT,VT0,Ymix,Yl1,YMF,struct('pbtmethod','pbt2x',...
       'interpV',job.extopts.pbtres,'extract_pial_white',mod(job.extopts.SRP,10), ...
       'Affine',res.Affine,'surf',{surf},'pbtlas',job.extopts.pbtlas, ... % pbtlas is the new parameter to reduce myelination effects
-      'inv_weighting',job.extopts.inv_weighting,'verb',job.extopts.verb,'WMT',WMT,'useprior',job.useprior),job); 
+      'inv_weighting',job.extopts.inv_weighting,'verb',job.extopts.verb,'useprior',job.useprior),job); 
   end
   
   % thickness map
@@ -818,8 +820,8 @@ if all( [job.output.surface>0 job.output.surface<9 ] ) || (job.output.surface==9
       [0,0.0001],job.output.ct,trans,single(Ycls{1})/255,0.1);
   end
   
-  if job.output.sROI && all(job.output.surface~=[5 6]) % no fast without registration
-    cat_io_cmd('  Surface ROI estimation');  
+  if job.output.sROI % no fast without registration
+    stime2 = cat_io_cmd('  Surface ROI estimation');  
     
     %% estimate surface ROI estimates for thickness
     [pp,ff]   = spm_fileparts(VT.fname);
@@ -1001,51 +1003,7 @@ end
 
 % final command line report
 cat_main_reportcmd(job,res,qa);
-%%
-%% cleanup fast
-try
-  delete_surf_preview(Psurf,job);
-end
-return
 
-function delete_surf_preview(Psurf,job)
-  % cleanup preview surfaces and directory (but only for non-experts)
-  if any( job.output.surface == [ 5 6 ] ) && job.extopts.expertgui<1
-    % delete files that where possibly created in cat_surf_createCS(2)
- 
-% RD202101: not all files are listed ... further lh.*.preview.* files: 
-%           - intlayer4, intpial, intwhite
-%           - layer4, pial, white
-
-    ffields = fieldnames(Psurf); 
-    for si = 1:numel( Psurf )
-      for fi = 1:numel( ffields )
-        [pp1,pp2] = spm_fileparts( spm_fileparts( Psurf(si).(ffields{fi}) ) );  
-        if exist( Psurf(si).(ffields{fi}) , 'file' ) && strcmp(pp2,'surf_preview') 
-          delete( Psurf(si).(ffields{fi}) ); 
-        end
-      end
-    end
-    
-    % remove the directory 
-    % (but only if it is empty (maybe used by parallel processes)
-    pp        = spm_fileparts( Psurf(1).Pcentral ); 
-    [pp1,pp2] = spm_fileparts( pp );  
-    dcontent  = dir( pp ); 
-    if exist( pp , 'dir' ) &&  strcmp(pp2,'surf_preview') && ...
-      numel( dcontent( [dcontent.isdir] == 0) ) == 0
-      try
-        rmdir( pp , 's');
-      end
-    end
-    % check also for an empty surf directory
-    if exist( pp , 'dir' ) &&  strcmp(pp2,'surf') && ...
-      numel( dcontent( [dcontent.isdir] == 0) ) == 0
-      try
-        rmdir( fullfile(pp,'surf') , 's');
-      end
-    end
-  end
 return
 function [Ysrc,Ycls,Yy,res] = cat_main_resspmres(Ysrc,Ycls,Yy,res)
 %% cat_main_resspmres
@@ -1252,64 +1210,31 @@ function [Ycls,Ym,Ymi,Yp0b,Yb,Yl1,Yy,YMF,indx,indy,indz,qa,job] = cat_main_SPMpp
   YMF = NS(Yl1,job.extopts.LAB.VT) | NS(Yl1,job.extopts.LAB.BG) | NS(Yl1,job.extopts.LAB.BG);  
 return
 
-function [Ymix,job,surf,WMT,stime] = cat_main_surf_preppara(Ymi,Yp0,job,vx_vol)
+function [Ymix,job,surf,stime] = cat_main_surf_preppara(Ymi,Yp0,job,vx_vol)
 %  ------------------------------------------------------------------------
 %  Prepare some variables for the surface processing.
 %  ------------------------------------------------------------------------
 
   stime = cat_io_cmd('Surface and thickness estimation'); 
-  
-  % specify WM/CSF width/depth/thickness estimation
-  if job.output.surface>10
-    job.output.surface = job.output.surface - 10;
-    WMT = 1; 
-  elseif job.extopts.experimental || job.extopts.expertgui==2
-    WMT = 1; 
-  else
-    WMT = 0; 
-  end
-  
+   
   % specify surface
   switch job.output.surface
-    case 1, surf = {'lh','rh'};
-    case 2, surf = {'lh','rh','cb'};
-    case 3, surf = {'lh'};
-    case 4, surf = {'rh'};
-    % fast surface reconstruction without simple spherical mapping     
-    case 5, surf = {'lhfst','rhfst'};                   
-    case 6, surf = {'lhfst','rhfst','cbfst'}; 
-    % fast surface reconstruction with simple spherical mapping     
-    case 7, surf = {'lhsfst','rhsfst'};                    
-    case 8, surf = {'lhsfst','rhsfst','cbsfst'};
-    % estimate only volumebased thickness
-    case 9, surf = {'lhv','rhv'}; 
-    otherwise, surf = {};
+    case {1,11}, surf = {'lh','rh'};
+    case {2,12}, surf = {'lh','rh','cb'};
+    case {9,19}, surf = {'lhv','rhv'}; % estimate only volumebased thickness
+    otherwise,   surf = {};
   end
   if ~job.output.surface && any( [job.output.ct.native job.output.ct.warped job.output.ct.dartel] )
     surf = {'lhv','rhv'}; 
   end
   
-  % lower resolution for fast surface estimation
-  if job.output.surface>4 && job.output.surface~=9 
-    try
-      if strcmp(job.extopts.species,'human')
-        job.extopts.pbtres = max(0.8,min([((min(vx_vol)^3)/2)^(1/3) 1.0]));
-      else
-        job.extopts.pbtres = max(0.4,min([((min(vx_vol)^3)/2)^(1/3) 1.0]));
-      end
-    catch
-      job.extopts.pbtres = max(0.8,min([((min(vx_vol)^3)/2)^(1/3) 1.0]));
-    end
-  end
-  
-  % surface creation and thickness estimation (only for test >> manual setting)
+  % surface creation and thickness estimation input map
   Yp0toC = @(c) 1-min(1,abs(Yp0-c));
   Yp0th  = @(c) cat_stat_nanmedian( Ymi(Yp0toC(c) > 0.5) ); 
-  if ( Yp0th(1) < Yp0th(2) ) && ( Yp0th(2) < Yp0th(3) ) && ( Yp0th(3) > 0.9 ) % if T1
-    Ymix = Ymi .* (Yp0>0.5); % | (cat_vol_morph(Yp0>0.5,'d') & Ymi<2/3)); %% using the Ymi map
-  %elseif  ( Yp0th(1) > Yp0th(2) ) && ( Yp0th(2) > Yp0th(3) ) % if T1
-  %  Ymix = (4/3 - Ymi) .* (Yp0>0.5);
-  else % use only the segmentation map if any other contrast (or for tests)
-    Ymix = Yp0 / 3;  
+  if job.output.surface < 10  &&  ...
+    ( Yp0th(1) < Yp0th(2) ) && ( Yp0th(2) < Yp0th(3) ) && ( Yp0th(3) > 0.9 ) 
+    Ymix = Ymi .* (Yp0>0.5); % using the locally intensity normalized T1 map Ymi 
+  else
+    Ymix = Yp0 / 3; % use the AMAP segmentation  
   end
 return

--- a/cat_main_reportfig.m
+++ b/cat_main_reportfig.m
@@ -1412,7 +1412,6 @@ function cat_main_reportfig(Ym,Yp0,Yl1,Psurf,job,qa,res,str)
               hSD{i} = cat_surf_renderv(CS,[],struct('rot','t','interp',1,'h',hCS));
             end
             
-            if any( job.output.surface == [5 6] ); fst = ' \color[rgb]{1 0 0}preview!'; else, fst = ''; end
             if ~sidehist
               if strcmpi(spm_check_version,'octave')
                 axes('Position',[0.58 0.022 0.3 0.007],'Parent',fg); image((121:1:120+surfcolors),'Parent',cc{4});
@@ -1421,7 +1420,7 @@ function cat_main_reportfig(Ym,Yp0,Yl1,Psurf,job,qa,res,str)
                 cc{4} = axes('Position',[0.58 0.022 0.3 0.007],'Parent',fg); image((121:1:120+surfcolors),'Parent',cc{4});
               end
               set(cc{4},'XTick',1:(surfcolors-1)/6:surfcolors,'xcolor',fontcolor,'ycolor',fontcolor,'XTickLabel',...
-                 {'0','1','2','3','4','5',['               6 mm' fst]},...
+                 {'0','1','2','3','4','5','               6 mm'},...
                 'YTickLabel','','YTick',[],'TickLength',[0 0],'FontName',fontname,'FontSize',fontsize-2,'FontWeight','normal');
             else
               %% histogram
@@ -1608,7 +1607,6 @@ function cat_main_reportfig(Ym,Yp0,Yl1,Psurf,job,qa,res,str)
 
           % colormap
           side  = hSD{1}{1}.cdata; 
-          if any( job.output.surface == [5 6] ); fst = ' \color[rgb]{1 0 0}preview!'; else, fst = ''; end
           
           % histogram 
           if strcmpi(spm_check_version,'octave')
@@ -1687,7 +1685,7 @@ function cat_main_reportfig(Ym,Yp0,Yl1,Psurf,job,qa,res,str)
                   'YTickLabel','','YTick',[],'TickLength',[0.01 0],'FontName',fontname,'FontSize',fontsize-2,'FontWeight','normal'); 
             else
               set(cc{4},'XTick',1:(surfcolors-1)/6:surfcolors,'xcolor',fontcolor,'ycolor',fontcolor,'XTickLabel',...
-                  {'0','1','2','3','4','5',[repmat(' ',1,10 + 10*(1-isempty(fst))) '6 mm' fst]},...
+                  {'0','1','2','3','4','5',[repmat(' ',1,10) '6 mm']},...
                   'YTickLabel','','YTick',[],'TickLength',[0.01 0],'FontName',fontname,'FontSize',fontsize-2,'FontWeight','normal'); 
             end
           

--- a/cat_main_reportstr.m
+++ b/cat_main_reportstr.m
@@ -395,7 +395,7 @@ function str = cat_main_reportstr(job,res,qa)
     end
   end
   
-  if isfield(qa.qualitymeasures,'SurfaceDefectArea') && ~isempty(qa.qualitymeasures.SurfaceDefectArea) && ~any(job.output.surface == [5 6])  && isfinite(qa.qualitymeasures.SurfaceDefectArea)
+  if isfield(qa.qualitymeasures,'SurfaceDefectArea') && ~isempty(qa.qualitymeasures.SurfaceDefectArea)  && isfinite(qa.qualitymeasures.SurfaceDefectArea)
     if job.extopts.expertgui
       str{2} = [str{2} struct('name',' Defect area:','value',marks2str(qa.qualityratings.SurfaceDefectArea,...
                 sprintf('%0.2f%%', qa.qualitymeasures.SurfaceDefectArea)))];

--- a/cat_main_updateSPM.m
+++ b/cat_main_updateSPM.m
@@ -789,7 +789,8 @@ function [Ysrc,Ycls,Yb,Yb0,Yy,job,res,trans,T3th,stime2] = cat_main_updateSPM(Ys
     job2.extopts.regstr       = 15;     % low resolution 
     job2.extopts.reg.nits     = 16;     % less iterations
     job2.extopts.reg.affreg   = 0;      % new affine registration
-    job2.extopts.shootingtpms(3:end) = [];             % remove high templates, we only need low frequency corrections
+    %job2.extopts.shootingtpms(3:end) = [];      % remove high templates, we only need low frequency corrections 
+                                                 % NO! This would cause problems with the interpolation
     res2 = res; 
     res2.do_dartel            = 2;      % use shooting
   else

--- a/cat_surf_createCS3.m
+++ b/cat_surf_createCS3.m
@@ -58,10 +58,7 @@ function [Yth,S,Psurf,res] = cat_surf_createCS3(V,V0,Ym,Ya,YMF,Ytemplate,Yb0,opt
   if ~exist('opt','var'), opt = struct(); end                 % create variable if not exist
   vx_vol        = sqrt(sum(V.mat(1:3,1:3).^2));               % further interpolation based on internal resolution 
   def.verb      = cat_get_defaults('extopts.expertgui');      % 0-none, 1-minimal, 2-default, 3-details, 4-debug
-  def.surf      = {'lh','rh'};                                % surface reconstruction setting with {'lh','rh','rc','lc'} and
-                                                              % additional fast option 'fst' (e.g., 'lhfst') without topo.-corr. and sphere-reg. 
-  
-  % reducepatch has some issues with self intersections and should only be used for "fast" option
+  def.surf      = {'lh','rh'};                                % surface reconstruction setting with {'lh','rh','cb'} 
   % There is a new SPM approach spm_mesh_reduce that is maybe more robust. 
   % Higher resolution is at least required for animal preprocessing that is given by cat_main.
   def.LAB                 = cat_get_defaults('extopts.LAB');  % brain regions 
@@ -84,21 +81,9 @@ function [Yth,S,Psurf,res] = cat_surf_createCS3(V,V0,Ym,Ya,YMF,Ytemplate,Yb0,opt
     
   % options that rely on other options
   opt                     = cat_io_updateStruct(def,opt); clear def; 
-  opt.fast                = any(~cellfun('isempty',strfind(opt.surf,'sfst'))) + ...
-                            any(~cellfun('isempty',strfind(opt.surf,'fst'))); % fast registration without topo.-corr. and sphere-reg.
   opt.vol                 = any(~cellfun('isempty',strfind(opt.surf,'v')));   % only volume-based thickness estimation  
-  opt.surf                = cat_io_strrep(opt.surf,{'sfst','fst','v'},'');    % after definition of the 'fast' and 'vol' varialbe we simplify 'surf'
+  opt.surf                = cat_io_strrep(opt.surf,'v','');                   % after definition of the 'vol' varialbe we simplify 'surf'
   opt.interpV             = max(0.1,min([opt.interpV,1.5]));                  % general limitation of the PBT resolution
- 
-  % call old CS2 pipeline for fast option
-  if opt.fast
-    [Yth,S,Psurf,res] = cat_surf_createCS2(V,V0,Ym,Ya,YMF,Ytemplate,opt,job);
-    return
-  end
-  
-  if any(~cellfun('isempty',strfind(opt.surf,'sfst')))
-    opt.pbtres   = 0.8;
-  end
   
   % for testing only  
   skip_registration = debug & 1;


### PR DESCRIPTION
Removed fast surface processing option (without or with fast surface registration) and corrected some bugs in the experimental cat_main pipeline. This also includes a additional setting in the output.surface parameter in the developer mode to test surface reconstruction with the AMAP label map rather than the intensity normalized map in case of T1w.