### PR TITLE
Bug fix to support template with different resolution and voxel size changes in the longitudinal pipeline. 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,24 @@
 ------------------------------------------------------------------------
+r2559 | robertdahnke | 2024-03-13 12:44:28
+
+Changed paths:
+ M CHANGES.txt
+ M cat_long_main.m
+ M cat_long_multi_run.m
+ M cat_main_registration.m
+ M cat_main_reportfig.m
+ M cat_main_write.m
+
+(1) Fixed:   Corrected issue in using other Templates and output resolutions
+             in the longitudinal pipeline. Use default 1.5 mm in average processing
+             that has to fit to the TPM in cat_long_main. Removed the warning
+             for different output resolutions in cat_long_multi_run. Corrected
+             definitions in cat_main_registration.   
+(2) Fixed:   Corrected problem with missing text in the cat_report. 
+(3) Fixed:   Corrected an bug in writing the affine/rigid background image in 
+             cat_main_write.
+(4) Fixed:   Corrected a bug
+------------------------------------------------------------------------
 r2558 | gaser | 2024-02-28 15:30:40
 
 Changed paths:

--- a/cat_long_main.m
+++ b/cat_long_main.m
@@ -529,13 +529,20 @@ if longmodel || longTPM
       end
     end
   end
-
+  
   % RD202102: differentiation between user levels not tested yet !
   if exist('extopts','var') && isfield(extopts,'bb')
     matlabbatch{mbi}.spm.tools.cat.estwrite.extopts.bb              = 1; % use TPM output BB 
   elseif exist('extopts','var') &&  isfield(extopts,'registration') && isfield(extopts.registration,'bb')
     matlabbatch{mbi}.spm.tools.cat.estwrite.extopts.registration.bb = 1; % use TPM output BB 
   end
+  % RD202403: run average for 1.5 mm to combine it with the TPM 
+  if exist('extopts','var') && isfield(extopts,'vox')
+    matlabbatch{mbi}.spm.tools.cat.estwrite.extopts.vox = 1.5; 
+  elseif exist('extopts','var') &&  isfield(extopts,'registration') && isfield(extopts.registration,'vox')
+    matlabbatch{mbi}.spm.tools.cat.estwrite.extopts.registration.vox = 1.5; 
+  end
+
 
   if exist('output','var') && ~isempty(output)
     matlabbatch{mbi}.spm.tools.cat.estwrite.output            = output;

--- a/cat_long_multi_run.m
+++ b/cat_long_multi_run.m
@@ -14,13 +14,6 @@ warning off;
 
 if isdeployed, job.nproc = 0; end
 
-if isfield(job.extopts,'vox') && job.extopts.vox ~= 1.5
-  job.extopts.vox = 1.5;
-  fprintf('\n---------------------------------------------------------------------------\n');
-  fprintf('Warning: No change of output voxel size possible for longitudinal pipeline!\n');
-  fprintf('---------------------------------------------------------------------------\n');
-end
-
 % use some options from GUI or default file
 opts        = job.opts;
 extopts     = job.extopts;

--- a/cat_main_registration.m
+++ b/cat_main_registration.m
@@ -327,7 +327,7 @@ end
   
       % resolutions:
       tmpres = abs(tmpM(1));                                                                   % template resolution 
-     %tpmres = abs(tpmM(1));                                                                   % TPM resolution 
+      tpmres = abs(tpmM(1));                                                                   % TPM resolution 
      %regres = reg(regstri).opt.rres; if isinf(regres), regres = tmpres; end                   % registration resolution
       newres = job.extopts.vox(voxi); if isinf(newres), newres = tmpres; end                   % output resolution
          
@@ -340,12 +340,14 @@ end
       % M0 for the individual volume
       % M1* for the different normalized spaces
       % Mad for the Dartel template with different BB as the TPM
-      M0   = res.image.mat;          
-      if isfield( job.extopts , 'bb' )  &&  numel( job.extopts.bb ) == 1  && job.extopts.bb == 1
-        M1 = tpmM;
-      else
-        imat = spm_imatrix(tmpM); imat(1:3) = imat(1:3) + imat(7:9).*(tdim - (newres/tmpres*odim))/2; imat(7:9) = imat(7:9) * newres/tmpres; M1   = spm_matrix(imat);
-      end
+      M0   = res.image.mat; 
+      % RD202403: modified to support output of the given voxel size vox - see also below.
+      %if isfield( job.extopts , 'bb' )  &&  numel( job.extopts.bb ) == 1  && job.extopts.bb == 1 %&& job.extopts.vox == abs(tmpM(1))
+      %  M1   = tpmM;  
+      %  imat = spm_imatrix(tmpM); imat(1:3) = imat(1:3) + imat(7:9).*(tdim - (newres/tmpres*odim))/2; imat(7:9) = imat(7:9) * newres/tmpres; M1   = spm_matrix(imat);
+      %else
+      imat = spm_imatrix(tmpM); imat(1:3) = imat(1:3) + imat(7:9).*(tdim - (newres/tmpres*odim))/2; imat(7:9) = imat(7:9) * newres/tmpres; M1   = spm_matrix(imat);
+      %end
       imat = spm_imatrix(eye(4)); imat(1:3) = imat(1:3) + imat(7:9).*(tdim - (newres/tmpres*odim))/2; imat(7:9) = imat(7:9) * newres/tmpres; Mad  = spm_matrix(imat);
       
       % affine and rigid parameters for registration 
@@ -468,12 +470,12 @@ end
         % mat matrices for different spaces
         % - here M1 == M1t
         M0     = res.image.mat;                                                       % for (interpolated) individual volume
-        if isfield( job.extopts , 'bb' )  &&  numel( job.extopts.bb ) == 1  && job.extopts.bb == 1
-          M1   = tpmM;
-        else
-          imat = spm_imatrix(tmpM); imat(1:3) = imat(1:3) + imat(7:9).*(tdim - (newres/tmpres*odim))/2; imat(7:9) = imat(7:9) * newres/tmpres; 
-          M1   = spm_matrix(imat);
-        end
+        % RD202403: modified to support output of the given voxel size vox - see also above.
+        %if isfield( job.extopts , 'bb' )  &&  numel( job.extopts.bb ) == 1  && job.extopts.bb == 1
+        %  M1   = tpmM;
+        %else
+        imat = spm_imatrix(tmpM); imat(1:3) = imat(1:3) + imat(7:9).*(tdim - (newres/tmpres*odim))/2; imat(7:9) = imat(7:9) * newres/tmpres; M1   = spm_matrix(imat);
+        %end
         
         % estimate the inverse transformation 
         yid             = spm_diffeo('invdef', Yy , sdim, inv(tpmM\M1), M1\res.Affine*M0); 

--- a/cat_main_reportfig.m
+++ b/cat_main_reportfig.m
@@ -42,6 +42,23 @@ function cat_main_reportfig(Ym,Yp0,Yl1,Psurf,job,qa,res,str)
   fg  = spm_figure('FindWin','Graphics'); 
   set(0,'CurrentFigure',fg)
   
+  % remove CAT12 figure background image from start
+  try
+    fgc = get(fg,'Children');
+    if ~isempty(fgc)
+      fgcc = get(fgc,'Children');
+      if ~isempty(fgcc)
+        % remove figure elements to prevent further interations
+        delete(fgcc);
+        spm_figure('Clear',fg)
+        
+        % run the reportfig function the first time to fully clear the 
+        % changes by the cat start figure
+        cat_main_reportfig(Ym,Yp0,Yl1,[],job,qa,res,str)
+      end
+    end
+  end
+
   def.extopts.report.useoverlay   = 2;  % different p0 overlays, described below in the Yp0 print settings
                                         % (0 - no, 1 - red mask, 2 - blue BG, red BVs, WMHs [default] ... )
   def.extopts.report.type         = 2;  % (1 - Yo,Ym,Yp0,CS-top, 2 - Yo,Yp0,CS-left-right-top) 
@@ -593,8 +610,8 @@ function cat_main_reportfig(Ym,Yp0,Yl1,Psurf,job,qa,res,str)
   end
   
   %% position values of the orthview/surface subfigures
-  pos = {[0.008 0.375 0.486 0.35]; [0.506 0.375 0.486 0.35]; ...
-         [0.008 0.010 0.486 0.35]; [0.506 0.010 0.486 0.35]};
+  pos = {[0.008 0.375 0.486 0.345]; [0.506 0.375 0.486 0.345]; ...
+         [0.008 0.010 0.486 0.345]; [0.506 0.010 0.486 0.345]};
   try spm_orthviews('Reset'); end
 
   % BB box is not optimal for all images


### PR DESCRIPTION
(1) Fixed:   Corrected issue in using other Templates and output resolutions
             in the longitudinal pipeline. Use default 1.5 mm in average processing
             that has to fit to the TPM in cat_long_main. Removed the warning
             for different output resolutions in cat_long_multi_run. Corrected
             definitions in cat_main_registration.
(2) Fixed:   Corrected problem with missing text in the cat_report.
(3) Fixed:   Corrected an bug in writing the affine/rigid background image in
             cat_main_write.
(4) Fixed:   Corrected a bug

Changed paths:
 M CHANGES.txt
 M cat_long_main.m
 M cat_long_multi_run.m
 M cat_main_registration.m
 M cat_main_reportfig.m
 M cat_main_write.m