### PR TITLE
Add CAT12 standalone build workflow

### DIFF
--- a/.github/workflows/compile_cat12.yml
+++ b/.github/workflows/compile_cat12.yml
@@ -1,0 +1,36 @@
+name: Build CAT12 standalone
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Checkout SPM
+        uses: actions/checkout@v3
+        with:
+          repository: spm/spm
+          path: spm
+      - name: Install CAT12 in SPM toolbox
+        run: |
+          mkdir -p spm/toolbox/cat12
+          rsync -a --exclude='.git' ./ spm/toolbox/cat12/
+      - name: Setup MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: R2023b
+      - name: Build standalone
+        run: |
+          matlab -batch "cd(fullfile('spm','config')); spm_make_standalone(fullfile('..','standalone'), {'toolbox/cat12'});"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cat12-${{ matrix.os }}
+          path: spm/standalone
+


### PR DESCRIPTION
## Summary
- build CAT12 with SPM using GitHub Actions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e9af16290832cba4cc66e3ef1fe52