### PR TITLE
Update compile workflow excludes

### DIFF
--- a/.github/workflows/compile_cat12.yml
+++ b/.github/workflows/compile_cat12.yml
@@ -21,7 +21,16 @@ jobs:
       - name: Install CAT12 in SPM toolbox
         run: |
           mkdir -p spm/toolbox/cat12
-          rsync -a --exclude='.git' ./ spm/toolbox/cat12/
+          rsync -a --exclude='.git' \
+            --exclude='batches/' \
+            --exclude='catQC/' \
+            --exclude='check_pipeline/' \
+            --exclude='development/' \
+            --exclude='html/' \
+            --exclude='internal/' \
+            --exclude='mexmaca/' \
+            --exclude='mexmaci/' \
+            ./ spm/toolbox/cat12/
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:


### PR DESCRIPTION
## Summary
- exclude non-essential folders from rsync step in compile_cat12.yml

## Testing
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685ea1858780832ca7f6c48f29f822aa