### PR TITLE
Fix Windows build shell

### DIFF
--- a/.github/workflows/compile_cat12.yml
+++ b/.github/workflows/compile_cat12.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - name: Update


### PR DESCRIPTION
## Summary
- ensure compile workflow uses bash on all platforms

## Testing
- `make -n`
- `make -n zip`


------
https://chatgpt.com/codex/tasks/task_e_685ea65bd8e0832ca8e9265044f90857