### PR TITLE
Fix Windows build workflow

### DIFF
--- a/.github/workflows/compile_cat12.yml
+++ b/.github/workflows/compile_cat12.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           repository: spm/spm
           path: spm
+      - name: Install rsync
+        if: runner.os == 'Windows'
+        run: choco install -y rsync
       - name: Install CAT12 in SPM toolbox
         run: |
           mkdir -p spm/toolbox/cat12


### PR DESCRIPTION
## Summary
- add Chocolatey step to install `rsync` when running on Windows

## Testing
- `make -n zip`

------
https://chatgpt.com/codex/tasks/task_e_685ea855b520832ca8e5fab4927fd658