### PR TITLE
Fix Windows backslash issue in ROI CSV export (cat_io_csv.m)

### DIFF
--- a/cat_io_csv.m
+++ b/cat_io_csv.m
@@ -153,7 +153,7 @@ function C=readcsv(filename,sheet,pos,opt)
  
 
   % es gibt hier ein problem mit 
-  % - sonderzeichen wie ���
+  % - sonderzeichen wie äöü
   % - anderen sonderzeichen 
   
   if strcmpi(spm_check_version,'octave') 
@@ -165,9 +165,9 @@ function C=readcsv(filename,sheet,pos,opt)
       C1  = char( min(255, max(0, double( C1 ))));
     end
   else
-    C1  = strrep(C1,'ä','�');
-    C1  = strrep(C1,'ü','�');
-    C1  = strrep(C1,'ö','�');
+    C1  = strrep(C1,'Ã¤','ä');
+    C1  = strrep(C1,'Ã¼','ü');
+    C1  = strrep(C1,'Ã¶','ö');
   end
 
   for i=1:size(C1,1)
@@ -249,7 +249,7 @@ function writecsv(filename,C,sheet,pos,opt)
     for j=1:size(C,2)
       if ~isstruct(C{i,j}) && ~iscell(C{i,j})
         if C{i,j}==round(C{i,j})
-          M{i}=[M{i} num2str(C{i,j},'%d') opt.delimiter];
+          M{i}=[M{i} num2str(strrep(num2str(C{i,j}), '\', '\\'),'%d') opt.delimiter];
         else
           switch opt.komma
             case '.',   M{i}=[M{i} num2str(C{i,j},opt.format) opt.delimiter];


### PR DESCRIPTION
When running “Estimate mean/volume inside ROI for external analysis” on Windows, CAT12 prints warnings like:

> "Warning: Escaped character '\(any letters)' is not valid."
<img width="1318" height="766" alt="Screenshot 2025-09-05 110430" src="https://github.com/user-attachments/assets/b1213119-175a-47f4-8797-588088489bf1" />


This causes the generated CSVs to be empty with no values and only headers as it couldn't locate the correct xml file.
<img width="1356" height="364" alt="Screenshot 2025-09-05 110345" src="https://github.com/user-attachments/assets/b5f2dc34-029e-41da-aafb-21c8683813a2" />

The issue comes from fprintf, which interprets \M or \U in the file paths on Windows as escape sequences.

This PR added the operator strrep to find any backslashes '\\' and replace them with double blackslashes '\\\\' for the script to read the correct file path.

**Tested on Windows: no warnings in console, and the CSVs were correctly generated and populated.**
<img width="390" height="62" alt="Screenshot 2025-09-05 151743" src="https://github.com/user-attachments/assets/15397f5f-b96b-4b53-8535-27838ccd4920" />

**Should be no effect on Linux/macOS behavior.**

Related to #39 #50 