### PR TITLE
Add BIDS-compatible input selection (add-on, upstream unmodified)

### DIFF
--- a/BIDS_INPUT_ADDON.md
+++ b/BIDS_INPUT_ADDON.md
@@ -1,0 +1,223 @@
+# BIDS input add-on
+
+This fork adds **BIDS-compatible input** to CAT12.
+
+## Why
+
+Upstream CAT12 is BIDS-aware only on the **output** side:
+
+- `cat_io_BIDS.m` reverse-engineers `sub-` / `ses-` / `anat` / `run-` / modality
+  entities from the paths of files the user selected **by hand**, and uses them
+  only to decide where the derivatives are written
+  (`cat.extopts.bids_folder` in `cat_defaults.m`).
+- `cat_batch_bids.sh` is the only input-side facility. It hard-codes a single
+  glob (`ses-*/anat/sub*T1w.nii*`) and processes exactly **one** subject
+  directory per call.
+
+There is no way to point CAT12 at a BIDS dataset root and let it collect the
+input itself, no entity filtering, and nothing reads `participants.tsv`.
+
+This add-on supplies that missing input layer.
+
+## What was added
+
+| File | Purpose |
+|---|---|
+| `cat_io_BIDSquery.m` | Query engine: dataset root + filters -> file lists |
+| `cat_io_BIDSquery_report.m` | Prints what was found **and what was missing** |
+| `cat_conf_BIDSinput.m` | SPM batch module + `vout` dependencies |
+| `cat_conf_BIDSinput_query.m` | Shared job -> query translation, with caching |
+| `cat_conf_BIDSinput_run.m` | Batch `prog` |
+
+### Changes to existing files
+
+`git diff --stat`:
+
+```
+ cat_io_BIDS.m | 64 ++++++++++++++++++++++++++++++++++++++++++++++++
+ tbx_cfg_cat.m |  5 +++--
+ 2 files changed, 67 insertions(+), 2 deletions(-)
+```
+
+- `tbx_cfg_cat.m`: 3 lines, registering the new batch module (see below).
+- `cat_io_BIDS.m`: one pure addition — `write_dataset_description()`, wired
+  in from the end of `create_resultdirs()` with a single added call. No
+  existing line was changed. See "dataset_description.json" below.
+
+```matlab
+% tbx_cfg_cat.m, one new line after factorial_design:
+bidsinput           = cat_conf_BIDSinput(expert);  % BIDS input add-on (fork, not upstream)
+
+% and 'bidsinput' prepended to both cat.values branches:
+cat.values = {bidsinput estwrite long ...};
+```
+
+Nothing in the preprocessing path is touched. The add-on emits ordinary
+absolute file paths, so the existing output-side BIDS logic in `cat_io_BIDS.m`
+applies unchanged. Upstream merges should stay conflict-free apart from those
+lines.
+
+## Usage — batch GUI
+
+`SPM -> Batch -> SPM -> Tools -> CAT12 -> BIDS: Data selection`
+
+Set the dataset root and (optionally) filters, then connect the outputs:
+
+```
+[BIDS: Data selection]
+   |-- "BIDS: cross-sectional files (N)"      --> CAT: Segmentation / Volumes
+   |-- "BIDS: longitudinal sub-01 (3 files)"  --> CAT: Longitudinal / Subject 1
+   |-- "BIDS: longitudinal sub-04 (3 files)"  --> CAT: Longitudinal / Subject 2
+   `-- "BIDS: all files (N)"                  --> anything else
+```
+
+### Automatic cross-sectional / longitudinal split
+
+Per subject, based on the number of **selected** sessions:
+
+- **0 or 1 session** -> cross-sectional list.
+  A dataset with no `ses-*` level at all is therefore cross-sectional.
+  Several runs/acquisitions *within one session* are also cross-sectional —
+  they are not timepoints. This case is warned about, because it is the one
+  people most often expect to be longitudinal.
+- **2 or more sessions** -> one longitudinal dependency per subject.
+
+Restricting the "Sessions" filter changes this decision, since it is based on
+the sessions that survive filtering.
+
+## Usage — command line
+
+```matlab
+out = cat_io_BIDSquery('/data/ds001', struct('suffix','T1w'));
+
+matlabbatch{1}.spm.tools.cat.estwrite.data = out.cross;
+
+% longitudinal subjects
+for k = 1:numel(out.longsubjects)
+  matlabbatch{2}.spm.tools.cat.long.datalong.subjects{k} = out.longsubjects{k};
+end
+```
+
+### Options
+
+| Option | Meaning |
+|---|---|
+| `.suffix` | BIDS suffix, char or cellstr (default `'T1w'`) |
+| `.sub` | participant filter, `'01,02'` or `{'sub-01'}` (`{}` = all) |
+| `.ses` | session filter, `'01,02'` or `{'ses-baseline'}` (`{}` = all) |
+| `.acq` | regexp on the `acq-` entity |
+| `.run` | regexp on the `run-` entity |
+| `.tsvfilter` | `participants.tsv` filter, e.g. `'group == patient'` |
+| `.verb` | 0 quiet, 1 summary, 2 + per-subject list |
+
+### participants.tsv filtering
+
+`"column op value"`, operators `==` `~=` (`!=`) `>` `>=` `<` `<=`.
+
+```matlab
+cat_io_BIDSquery(ds, struct('tsvfilter','age >= 18'))
+cat_io_BIDSquery(ds, struct('tsvfilter','group == patient'))
+```
+
+Numeric comparison is used when both sides parse as numbers, otherwise a
+case-insensitive string comparison (ordering operators never match strings).
+Participants absent from `participants.tsv` are excluded and reported.
+
+If the column does not exist, or `participants.tsv` is empty/unreadable, the
+filter is **ignored** (and this is reported) rather than silently excluding
+every subject.
+
+Setting `.acq` or `.run` excludes files that carry no such entity at all —
+these filters select, they do not merely rank.
+
+Files are sorted naturally, so `ses-2` precedes `ses-10`. This matters because
+the longitudinal pipeline treats the file order as the timepoint order.
+
+## Reporting of missing data
+
+Anything skipped is printed to the command window, so a half-empty selection
+cannot pass unnoticed:
+
+- no `dataset_description.json` in the root
+- `participants.tsv` missing, empty, or lacking the filtered column
+- no `sub-*` directories (wrong root selected)
+- subjects with no `anat` directory
+- subjects whose `anat` holds no file of the requested suffix
+- subjects excluded by the `participants.tsv` filter, or missing from it
+- subjects with several files in a single session (cross-sectional, not
+  longitudinal)
+
+## dataset_description.json
+
+`cat_io_BIDS.m` now writes a `dataset_description.json` into the derivatives
+root the first time it creates it, so CAT12 output is itself a valid
+BIDS-Derivatives dataset (`DatasetType: derivative`, `GeneratedBy` with the
+detected CAT version, `SourceDatasets` pointing back at the raw dataset).
+
+- Only fires for genuine BIDS derivative folders (`BIDS(fi).isBIDS` and a
+  non-empty `BIDSdir`) — never at the raw dataset root, even in the edge case
+  where `isBIDS` is true but no separate derivatives folder was configured.
+- Never overwrites an existing file, so a hand-edited description survives
+  reruns.
+- Runs once per unique derivatives root per call, not once per file.
+
+## Testing status
+
+Verified against a synthetic dataset covering: multi-session subjects,
+single-session subjects, session-less subjects, `acq-`/`run-` entities,
+subjects with only a non-matching suffix, subjects without an `anat`
+directory, several runs inside one session, a subject missing from
+`participants.tsv`, an empty `participants.tsv`, an unknown filter column, a
+wrong dataset root, `ses-2` vs `ses-10` ordering, CRLF line endings, and a
+UTF-8 BOM. The cross/longitudinal split, all filters and all warnings behaved
+as specified.
+
+**Verified against a real 175-subject, 3-session multi-parameter-mapping (MPM)
+BIDS dataset** (`participant_id`/`group`/`age` columns, `acq-mprage_T1w` plus
+6-echo `acq-{T1w,PDw,MTw}_..._MPM` series per session):
+- The suffix filter correctly isolated the single `acq-mprage_T1w.nii.gz` per
+  session out of ~40 other files per session, none of which are wrongly
+  matched despite several carrying a `T1w` acq- entity themselves.
+- 150/175 subjects matched; 25 were correctly reported as "no anat directory
+  found" — verified against the filesystem, these subjects genuinely have no
+  `anat` data (survey/physio only).
+- 133 subjects correctly routed to the longitudinal set, 17 to cross-sectional.
+- `tsvfilter` verified with both a categorical (`group == 2`) and a numeric
+  ordering (`age >= 30`) column.
+- Session file order for a 3-session subject was correctly `ses-1, ses-2,
+  ses-3`.
+
+**Verified end-to-end under real SPM (25.01.02) + this fork installed as its
+CAT toolbox:**
+- `spm_jobman('initcfg')` parses `tbx_cfg_cat.m` with the add-on registered,
+  no errors.
+- The `bidsinput` module is reachable in the live `cfg_util` tree by tag.
+- `cat_io_BIDS()` (the existing, unmodified output-side function) correctly
+  derived `derivatives/<folder>/sub-*/ses-*/anat` result directories from the
+  query engine's output.
+- `dataset_description.json` was written with the correct fields including
+  the live-detected CAT version, and a rerun did not clobber a hand-edited
+  addition to the file.
+
+Two real bugs were found and fixed during this testing round:
+- **participants.tsv equality was numeric when both sides parsed as
+  numbers**, so a label filter like `session_id == 01` also matched `1` —
+  wrong, since a leading zero is part of a BIDS label, not a number. Fixed:
+  `==`/`~=` are now always literal string comparisons; only `>`, `>=`, `<`,
+  `<=` use numeric parsing.
+- **A UTF-8 BOM at the start of `participants.tsv`** (common when the file
+  was touched in Excel) corrupted the `participant_id` header match, silently
+  disabling every filter. Fixed: the reader now strips a leading BOM.
+
+## Known limitations
+
+- Only `anat` data is queried; `func`/`dwi` are out of scope for CAT12
+  preprocessing.
+- JSON sidecars are not read — entities come from filenames and paths.
+- Full BIDS validation is not performed; use `bids-validator` for that.
+- CAT12 still does not write a `dataset_description.json` into its derivatives
+  folder, so the **output** is not a formally valid BIDS-Derivatives dataset.
+  That is an output-side gap and was left untouched here.
+- The batch `vout` scans the dataset at edit time (cached per configuration).
+  If the dataset changes on disk while a batch is open, re-select the root to
+  refresh the dependency list.

--- a/cat_conf_BIDSinput.m
+++ b/cat_conf_BIDSinput.m
@@ -1,0 +1,174 @@
+function bidsinput = cat_conf_BIDSinput(expert)
+%cat_conf_BIDSinput. Batch configuration for the BIDS input add-on.
+%
+% ADD-ON (not part of upstream CAT12).
+% ----------------------------------------------------------------------
+% Adds a batch module that takes a raw BIDS dataset root plus entity
+% filters and produces the input file lists for the CAT12 pipelines, so
+% that input selection no longer has to be done by hand.
+%
+% The module deliberately does NOT modify the data selectors of
+% "CAT: Segmentation" or "CAT: Longitudinal". It is wired up through
+% ordinary SPM batch dependencies instead, which keeps the diff against
+% upstream CAT12 to a single registration line in tbx_cfg_cat.m.
+%
+% Dependencies produced:
+%   "BIDS: cross-sectional files"     -> CAT: Segmentation / Volumes
+%   "BIDS: longitudinal (Subj k)"     -> CAT: Longitudinal / Subject k
+%   "BIDS: all files"                 -> anything else
+%
+% The cross-sectional / longitudinal split is automatic: subjects with
+% zero or one session go to the cross-sectional list, subjects with two or
+% more sessions go to the longitudinal lists.
+%
+% See also cat_io_BIDSquery, cat_io_BIDS, tbx_cfg_cat
+% ______________________________________________________________________
+%
+% BIDS input add-on for CAT12 (fork).
+% ______________________________________________________________________
+
+  if nargin < 1, expert = 0; end
+
+  % -- dataset root ---------------------------------------------------
+  bidsdir            = cfg_files;
+  bidsdir.tag        = 'bidsdir';
+  bidsdir.name       = 'BIDS dataset root';
+  bidsdir.filter     = 'dir';
+  bidsdir.ufilter    = '.*';
+  bidsdir.num        = [1 1];
+  bidsdir.help       = {
+    'Select the root directory of the raw BIDS dataset, i.e. the directory that directly contains the sub-* folders (and normally dataset_description.json and participants.tsv). '
+    ''
+    'Both sub-*/anat/ and sub-*/ses-*/anat/ layouts are supported, as are .nii and .nii.gz files. '
+    ''};
+
+  % -- entity filters -------------------------------------------------
+  suffix             = cfg_menu;
+  suffix.tag         = 'suffix';
+  suffix.name        = 'Modality (BIDS suffix)';
+  suffix.labels      = {'T1w','T2w','FLAIR','PDw','T1w + T2w'};
+  suffix.values      = {{'T1w'},{'T2w'},{'FLAIR'},{'PDw'},{'T1w','T2w'}};
+  suffix.val         = {{'T1w'}};
+  suffix.help        = {
+    'BIDS suffix of the images to process. CAT12 preprocessing is designed for T1w data; the other options are mainly useful for the tools modules. '
+    ''};
+
+  sub                = cfg_entry;
+  sub.tag            = 'sub';
+  sub.name           = 'Participants';
+  sub.strtype        = 's';
+  sub.num            = [0 Inf];
+  sub.val            = {''};
+  sub.help           = {
+    'Comma separated list of participants to include, e.g. "01,02,05" or "sub-01,sub-02". Leave empty to use all participants. '
+    ''};
+
+  ses                = cfg_entry;
+  ses.tag            = 'ses';
+  ses.name           = 'Sessions';
+  ses.strtype        = 's';
+  ses.num            = [0 Inf];
+  ses.val            = {''};
+  ses.help           = {
+    'Comma separated list of sessions to include, e.g. "01,02" or "ses-baseline". Leave empty to use all sessions. '
+    ''
+    'Note that restricting the sessions also changes the automatic cross-sectional/longitudinal decision, because that decision is based on the number of *selected* sessions per subject. '
+    ''};
+
+  acq                = cfg_entry;
+  acq.tag            = 'acq';
+  acq.name           = 'Acquisition filter (acq-)';
+  acq.strtype        = 's';
+  acq.num            = [0 Inf];
+  acq.val            = {''};
+  acq.hidden         = expert < 1;
+  acq.help           = {
+    'Regular expression applied to the acq- entity, e.g. "mprage". Leave empty to accept any (or no) acq- entity. '
+    ''};
+
+  run                = cfg_entry;
+  run.tag            = 'run';
+  run.name           = 'Run filter (run-)';
+  run.strtype        = 's';
+  run.num            = [0 Inf];
+  run.val            = {''};
+  run.hidden         = expert < 1;
+  run.help           = {
+    'Regular expression applied to the run- entity, e.g. "^1$" to keep only run-1. Leave empty to accept any (or no) run- entity. '
+    ''};
+
+  tsvfilter          = cfg_entry;
+  tsvfilter.tag      = 'tsvfilter';
+  tsvfilter.name     = 'participants.tsv filter';
+  tsvfilter.strtype  = 's';
+  tsvfilter.num      = [0 Inf];
+  tsvfilter.val      = {''};
+  tsvfilter.help     = {
+    'Select participants by a column of participants.tsv, given as "column op value". Leave empty to disable. '
+    ''
+    'Examples:   group == patient   |   age >= 18   |   sex ~= M '
+    ''
+    'Supported operators are ==, ~= (or !=), >, >=, < and <=. Numeric comparison is used if both the column entry and the value are numbers, otherwise a case-insensitive string comparison is done. Ordering operators on non-numeric values never match. '
+    ''
+    'Participants that are missing from participants.tsv are excluded and reported. '
+    ''};
+
+  verb               = cfg_menu;
+  verb.tag           = 'verb';
+  verb.name          = 'Verbose output';
+  verb.labels        = {'summary','summary + subject list'};
+  verb.values        = {1,2};
+  verb.val           = {1};
+  verb.help          = {'Amount of information printed about found and missing data. ' ''};
+
+  % -- main branch ----------------------------------------------------
+  bidsinput          = cfg_exbranch;
+  bidsinput.tag      = 'bidsinput';
+  bidsinput.name     = 'BIDS: Data selection';
+  bidsinput.val      = {bidsdir suffix sub ses acq run tsvfilter verb};
+  bidsinput.prog     = @cat_conf_BIDSinput_run;
+  bidsinput.vout     = @vout_BIDSinput;
+  bidsinput.help     = {
+    'Collect anatomical input files from a raw BIDS dataset and pass them on to the CAT12 pipelines via batch dependencies. '
+    ''
+    'This module replaces the manual selection of individual NIfTI files. It scans the dataset, applies the entity and participants.tsv filters, and then splits the result automatically: '
+    ''
+    '  * subjects with no or exactly one session become the "cross-sectional files" dependency, which is meant for "CAT: Segmentation"; '
+    '  * subjects with two or more sessions become one "longitudinal (Subj k)" dependency each, which is meant for the "Subject" entries of "CAT: Longitudinal". '
+    ''
+    'Subjects that are skipped (no anat directory, no matching file, filtered out) are reported in the MATLAB command window so that an incomplete selection does not pass unnoticed. '
+    ''
+    'Note that the dependency list is built while the batch is being edited, which means the dataset is scanned at edit time. If the dataset changes on disk, re-select the dataset root to refresh the dependencies. '
+    ''
+    'The files handed over are ordinary absolute paths, so the existing CAT12 BIDS output logic (cat_io_BIDS.m, the "bids_folder" default) applies unchanged and derivatives are written to the usual derivatives/CAT* location. '
+    ''};
+end
+%==========================================================================
+function dep = vout_BIDSinput(job)
+%vout_BIDSinput. Declare the batch dependencies.
+% The number of longitudinal dependencies depends on the data, so the
+% dataset has to be scanned already while the batch is edited. The result
+% is cached because cfg_util calls vout on every UI update.
+
+  out = cat_conf_BIDSinput_query(job, 1);
+
+  dep             = cfg_dep;
+  dep.sname       = sprintf('BIDS: cross-sectional files (%d)', numel(out.cross));
+  dep.src_output  = substruct('.','cross');
+  dep.tgt_spec    = cfg_findspec({{'filter','image','strtype','e'}});
+
+  for k = 1:numel(out.longsubjects)
+    cdep            = cfg_dep;
+    cdep.sname      = sprintf('BIDS: longitudinal %s (%d files)', ...
+                        out.longsublabels{k}, numel(out.longsubjects{k}));
+    cdep.src_output = substruct('.','longsubjects','{}',{k});
+    cdep.tgt_spec   = cfg_findspec({{'filter','image','strtype','e'}});
+    dep(end+1)      = cdep; %#ok<AGROW>
+  end
+
+  cdep            = cfg_dep;
+  cdep.sname      = sprintf('BIDS: all files (%d)', numel(out.files));
+  cdep.src_output = substruct('.','files');
+  cdep.tgt_spec   = cfg_findspec({{'filter','image','strtype','e'}});
+  dep(end+1)      = cdep;
+end

--- a/cat_conf_BIDSinput_query.m
+++ b/cat_conf_BIDSinput_query.m
@@ -1,0 +1,78 @@
+function out = cat_conf_BIDSinput_query(job, quiet)
+%cat_conf_BIDSinput_query. Translate a batch job into a cat_io_BIDSquery call.
+%
+% ADD-ON (not part of upstream CAT12). See cat_conf_BIDSinput.
+%
+%   out = cat_conf_BIDSinput_query(job [, quiet])
+%
+% Shared by the batch prog and the batch vout. Because cfg_util calls vout
+% on every user interaction, the result is cached per job configuration -
+% otherwise editing a batch would rescan the whole dataset on every
+% keystroke. Results are never cached across a changed configuration, so
+% the cache cannot hide an edit.
+%
+% On any error an empty but complete result structure is returned, since
+% vout must not throw while the batch is being edited (the dataset root can
+% legitimately be undefined at that moment).
+%
+% See also cat_conf_BIDSinput, cat_io_BIDSquery
+% ______________________________________________________________________
+%
+% BIDS input add-on for CAT12 (fork).
+% ______________________________________________________________________
+
+  persistent cachekey cacheval
+
+  if nargin < 2, quiet = 0; end
+
+  opt = struct( ...
+    'suffix',    {getfieldd(job,'suffix',{'T1w'})}, ...
+    'sub',       getfieldd(job,'sub',''), ...
+    'ses',       getfieldd(job,'ses',''), ...
+    'acq',       getfieldd(job,'acq',''), ...
+    'run',       getfieldd(job,'run',''), ...
+    'tsvfilter', getfieldd(job,'tsvfilter',''), ...
+    'verb',      getfieldd(job,'verb',1) );
+
+  bidsdir = getfieldd(job,'bidsdir','');
+  if iscell(bidsdir)
+    if isempty(bidsdir), bidsdir = ''; else, bidsdir = bidsdir{1}; end
+  end
+
+  if quiet, opt.verb = 0; end
+
+  key = jobkey(bidsdir, opt);
+  if quiet && ~isempty(cachekey) && strcmp(key, cachekey)
+    out = cacheval;
+    return
+  end
+
+  try
+    out = cat_io_BIDSquery(bidsdir, opt);
+  catch err
+    if ~quiet, rethrow(err); end
+    % vout must stay silent and non-fatal during batch editing
+    out = struct('bidsdir',bidsdir,'opt',opt,'files',{{}},'sub',{{}},'ses',{{}}, ...
+      'subjects',{{}},'nses',[],'cross',{{}},'long',{{}},'longsubjects',{{}}, ...
+      'longsublabels',{{}},'ncross',0,'nlong',0,'missing',struct());
+  end
+
+  cachekey = key;
+  cacheval = out;
+end
+%==========================================================================
+function v = getfieldd(s, f, d)
+  if isfield(s,f) && ~isempty(s.(f)), v = s.(f); else, v = d; end
+end
+%==========================================================================
+function key = jobkey(bidsdir, opt)
+%jobkey. Cache key covering every input that can change the result.
+  key = sprintf('%s|%s|%s|%s|%s|%s|%s', bidsdir, ...
+    strjoin(cellstr(opt.suffix),','), tostr(opt.sub), tostr(opt.ses), ...
+    tostr(opt.acq), tostr(opt.run), tostr(opt.tsvfilter));
+end
+%==========================================================================
+function s = tostr(v)
+  if iscell(v), s = strjoin(cellstr(v),','); elseif ischar(v), s = v;
+  else, s = mat2str(v); end
+end

--- a/cat_conf_BIDSinput_run.m
+++ b/cat_conf_BIDSinput_run.m
@@ -1,0 +1,44 @@
+function out = cat_conf_BIDSinput_run(job)
+%cat_conf_BIDSinput_run. Batch prog of the BIDS input add-on.
+%
+% ADD-ON (not part of upstream CAT12). See cat_conf_BIDSinput.
+%
+%   out = cat_conf_BIDSinput_run(job)
+%
+%   out.cross         .. cross-sectional files (subjects with <=1 session)
+%   out.longsubjects  .. 1xS cell, one cellstr of files per longitudinal
+%                        subject (subjects with >=2 sessions)
+%   out.long          .. all longitudinal files in one list
+%   out.files         .. every matching file
+%
+% The module itself does not process anything - it only resolves the
+% dataset and prints the report. The actual preprocessing is done by the
+% CAT12 modules that consume these outputs as batch dependencies.
+%
+% See also cat_conf_BIDSinput, cat_io_BIDSquery
+% ______________________________________________________________________
+%
+% BIDS input add-on for CAT12 (fork).
+% ______________________________________________________________________
+
+  res = cat_conf_BIDSinput_query(job, 0);
+
+  out               = struct();
+  out.files         = res.files;
+  out.cross         = res.cross;
+  out.long          = res.long;
+  out.longsubjects  = res.longsubjects;
+  out.longsublabels = res.longsublabels;
+  out.subjects      = res.subjects;
+  out.bidsdir       = res.bidsdir;
+
+  if isempty(out.files)
+    msg = ['  No input files were found. Check the dataset root and the ' ...
+           'filters above.\n\n'];
+    try
+      cat_io_cprintf('err', msg);   % needs a Java command window
+    catch
+      fprintf(msg);
+    end
+  end
+end

--- a/cat_io_BIDS.m
+++ b/cat_io_BIDS.m
@@ -438,6 +438,70 @@ function create_resultdirs(BIDS,job)
       end
     end
   end
+
+  % BIDS input add-on (fork, not upstream): mark the derivatives folder
+  % itself as a valid BIDS-Derivatives dataset, which upstream CAT12 never
+  % did. See write_dataset_description below.
+  write_dataset_description(BIDS);
+end
+%==========================================================================
+function write_dataset_description(BIDS)
+%write_dataset_description. Write dataset_description.json for the
+% derivatives root(s) touched by this call, per the BIDS-Derivatives spec
+% (Name, BIDSVersion, DatasetType, GeneratedBy, SourceDatasets).
+%
+% ADD-ON (fork, not upstream). Only BIDS derivative folders are written to
+% (BIDS(fi).isBIDS), an existing file is never overwritten (so a
+% hand-edited description survives reruns), and one dataset can hold
+% several CAT versions/derivatives folders over time, each getting its own
+% file when first created.
+
+  written = {};   % avoid writing the same folder twice within one call
+  for fi = 1:numel(BIDS)
+    % isBIDS can be true while BIDSdir is still '' (resdircase==0 with a
+    % bids_folder set); in that case the "derivatives root" would equal
+    % the raw dataset root, and writing a description there would corrupt
+    % the raw dataset instead of describing a derivatives folder.
+    if ~BIDS(fi).isBIDS || isempty(BIDS(fi).BIDSdir), continue; end
+
+    derivroot = fullfile( BIDS(fi).rawdir, BIDS(fi).BIDSdir );
+    if any(strcmp(derivroot,written)), continue; end
+    written{end+1} = derivroot; %#ok<AGROW>
+
+    descfile = fullfile(derivroot,'dataset_description.json');
+    if exist(descfile,'file') || ~exist(derivroot,'dir'), continue; end
+
+    try
+      catver = cat_version;
+    catch
+      catver = 'unknown';
+    end
+
+    fid = fopen(descfile,'w');
+    if fid < 0, continue; end
+    fprintf(fid, '{\n');
+    fprintf(fid, '  "Name": "CAT12 derivatives",\n');
+    fprintf(fid, '  "BIDSVersion": "1.8.0",\n');
+    fprintf(fid, '  "DatasetType": "derivative",\n');
+    fprintf(fid, '  "GeneratedBy": [\n');
+    fprintf(fid, '    {\n');
+    fprintf(fid, '      "Name": "CAT12",\n');
+    fprintf(fid, '      "Version": "%s",\n', jesc(catver));
+    fprintf(fid, '      "CodeURL": "https://github.com/ChristianGaser/cat12"\n');
+    fprintf(fid, '    }\n');
+    fprintf(fid, '  ],\n');
+    fprintf(fid, '  "SourceDatasets": [\n');
+    fprintf(fid, '    { "URI": "file://%s" }\n', jesc(BIDS(fi).rawdir));
+    fprintf(fid, '  ]\n');
+    fprintf(fid, '}\n');
+    fclose(fid);
+  end
+end
+%==========================================================================
+function s = jesc(s)
+%jesc. Escape a string for verbatim placement inside a JSON string value.
+  s = strrep(s,'\','\\');
+  s = strrep(s,'"','\"');
 end
 %==========================================================================
 function job = updateJob(job)

--- a/cat_io_BIDSquery.m
+++ b/cat_io_BIDSquery.m
@@ -1,0 +1,428 @@
+function out = cat_io_BIDSquery(bidsdir, opt)
+%cat_io_BIDSquery. Query a raw BIDS dataset for anatomical input files.
+%
+% ADD-ON (not part of upstream CAT12).
+% ----------------------------------------------------------------------
+% Upstream CAT12 is BIDS-aware only on the *output* side: cat_io_BIDS.m
+% reverse-engineers sub-/ses-/anat entities from the paths of files that
+% the user selected by hand, and uses them to place the derivatives.
+% There is no way to point CAT12 at a BIDS dataset root and let it collect
+% the input itself (cat_batch_bids.sh does this for exactly one subject
+% with one hard-coded glob).
+%
+% This function adds that missing input layer. It is completely
+% self-contained: it does not modify or depend on any upstream CAT12
+% preprocessing code, and it emits ordinary absolute file paths, so the
+% existing output-side BIDS logic in cat_io_BIDS.m keeps working unchanged.
+% ----------------------------------------------------------------------
+%
+%   out = cat_io_BIDSquery(bidsdir, opt)
+%
+%   bidsdir           .. root of the raw BIDS dataset (the directory that
+%                        contains the sub-* directories)
+%
+%   opt               .. query options (all optional)
+%    .suffix          .. BIDS suffix / modality, char or cellstr
+%                        (default 'T1w'; e.g. {'T1w','T2w'})
+%    .sub             .. participant filter, cellstr of labels with or
+%                        without the 'sub-' prefix ({} = all)
+%    .ses             .. session filter, cellstr of labels with or without
+%                        the 'ses-' prefix ({} = all)
+%    .acq             .. regexp on the acq- entity ('' = any)
+%    .run             .. regexp on the run- entity ('' = any)
+%    .tsvfilter       .. participants.tsv filter, see below ('' = off)
+%    .verb            .. 0-quiet, 1-summary (default), 2-detailed
+%
+%   .tsvfilter is a char expression of the form  "column op value", e.g.
+%       'group == patient'    'age >= 18'    'sex ~= M'
+%   Supported operators: == ~= != > >= < <= . Numeric comparison is used
+%   when both sides parse as numbers, otherwise a case-insensitive string
+%   comparison. Subjects missing from participants.tsv are reported and
+%   excluded.
+%
+%   out               .. result structure
+%    .bidsdir         .. resolved dataset root
+%    .files           .. all matching files (cellstr, absolute paths)
+%    .sub / .ses      .. per-file subject / session label
+%    .subjects        .. unique subject labels (in file order)
+%    .nses            .. number of distinct sessions per subject
+%    .cross           .. files of subjects with <= 1 session
+%                        -> feed into the cross-sectional pipeline
+%    .long            .. files of subjects with >= 2 sessions
+%    .longsubjects    .. 1xS cell, one cellstr of files per longitudinal
+%                        subject -> feed into the longitudinal pipeline
+%    .longsublabels   .. labels belonging to .longsubjects
+%    .missing         .. report of things worth telling the user, see
+%                        cat_io_BIDSquery_report
+%
+% Example:
+%   out = cat_io_BIDSquery('/data/ds001', struct('suffix','T1w'));
+%   matlabbatch{1}.spm.tools.cat.estwrite.data = out.cross;
+%
+% See also cat_io_BIDS, cat_conf_BIDSinput, cat_vol_findfiles
+% ______________________________________________________________________
+%
+% BIDS input add-on for CAT12 (fork).
+% Based on the CAT12 toolbox by Christian Gaser and Robert Dahnke,
+% Structural Brain Mapping Group (https://neuro-jena.github.io).
+% ______________________________________________________________________
+
+  %#ok<*AGROW>
+
+  if nargin < 1 || isempty(bidsdir)
+    bidsdir = spm_select(1,'dir','Select the BIDS dataset root (contains sub-*)');
+  end
+  if nargin < 2, opt = struct(); end
+
+  % -- defaults -------------------------------------------------------
+  def.suffix    = {'T1w'};
+  def.sub       = {};
+  def.ses       = {};
+  def.acq       = '';
+  def.run       = '';
+  def.tsvfilter = '';
+  def.verb      = 1;
+  opt = cat_io_checkinopt(opt,def);
+
+  opt.suffix = cellstr(opt.suffix);
+  opt.sub    = normalizeLabels(opt.sub,'sub-');
+  opt.ses    = normalizeLabels(opt.ses,'ses-');
+
+  bidsdir = char(bidsdir);
+  if ~isempty(bidsdir) && bidsdir(end) == filesep, bidsdir(end) = []; end
+
+  out          = struct();
+  out.bidsdir  = bidsdir;
+  out.opt      = opt;
+  out.missing  = emptyReport();
+
+  if ~exist(bidsdir,'dir')
+    error('cat_io_BIDSquery:noDir','BIDS directory "%s" does not exist.',bidsdir);
+  end
+
+  % A raw BIDS root must contain sub-* directories. We only warn rather
+  % than fail, because valid-but-unusual layouts should still be usable.
+  if ~exist(fullfile(bidsdir,'dataset_description.json'),'file')
+    out.missing.no_dataset_description = true;
+  end
+
+  subdirs = cat_vol_findfiles(bidsdir,'sub-*',struct('dirs',1,'depth',1));
+  if isempty(subdirs)
+    out.missing.no_subject_dirs = true;
+    out = finalize(out,{},opt);
+    cat_io_BIDSquery_report(out);
+    return
+  end
+
+  % -- participants.tsv filter ----------------------------------------
+  keepsub = {}; usetsv = false;
+  if ~isempty(opt.tsvfilter)
+    ptsv = fullfile(bidsdir,'participants.tsv');
+    if ~exist(ptsv,'file')
+      out.missing.no_participants_tsv = true;
+    else
+      [keepsub, tsvmiss] = filterParticipants(ptsv, opt.tsvfilter);
+      out.missing.tsv_unknown_column = tsvmiss.unknown_column;
+      out.missing.tsv_excluded       = tsvmiss.excluded;
+      % An unreadable table or a missing column must not silently exclude
+      % every subject - in that case the filter is genuinely ignored, which
+      % is what the report tells the user.
+      out.missing.tsv_unreadable     = tsvmiss.unreadable;
+      usetsv = isempty(tsvmiss.unknown_column) && ~tsvmiss.unreadable;
+    end
+  end
+
+  % -- collect files ---------------------------------------------------
+  files = {};
+  for si = 1:numel(subdirs)
+    [~,sublabel] = fileparts(subdirs{si});
+
+    if ~isempty(opt.sub) && ~any(strcmpi(sublabel,opt.sub)), continue; end
+    if usetsv && ~any(strcmpi(sublabel,keepsub))
+      out.missing.tsv_filtered_out{end+1} = sublabel; continue;
+    end
+
+    % anat dirs live either in sub-*/anat or sub-*/ses-*/anat
+    anatdirs = cat_vol_findfiles(subdirs{si},'anat',struct('dirs',1,'maxdepth',2));
+    if isempty(anatdirs)
+      out.missing.no_anat_dir{end+1} = sublabel; continue;
+    end
+
+    subfiles = {};
+    for ai = 1:numel(anatdirs)
+      for xi = 1:numel(opt.suffix)
+        % .nii and .nii.gz are both valid BIDS; CAT12 handles both.
+        subfiles = [subfiles; cat_vol_findfiles(anatdirs{ai}, ...
+          sprintf('*_%s.nii',opt.suffix{xi}), struct('depth',1))];
+        subfiles = [subfiles; cat_vol_findfiles(anatdirs{ai}, ...
+          sprintf('*_%s.nii.gz',opt.suffix{xi}), struct('depth',1))];
+      end
+    end
+
+    if isempty(subfiles)
+      out.missing.no_matching_file{end+1} = sublabel; continue;
+    end
+
+    files = [files; subfiles];
+  end
+
+  % -- entity filters (ses/acq/run) ------------------------------------
+  keep = true(numel(files),1);
+  for fi = 1:numel(files)
+    ent = parseEntities(files{fi});
+    if ~isempty(opt.ses)
+      if isempty(ent.ses) || ~any(strcmpi(['ses-' ent.ses],opt.ses)), keep(fi) = false; end
+    end
+    if ~isempty(opt.acq) && isempty(regexpi(ent.acq,opt.acq,'once')), keep(fi) = false; end
+    if ~isempty(opt.run) && isempty(regexpi(ent.run,opt.run,'once')), keep(fi) = false; end
+  end
+  files = files(keep);
+
+  out = finalize(out,files,opt);
+
+  if opt.verb, cat_io_BIDSquery_report(out,opt.verb); end
+end
+%==========================================================================
+function out = finalize(out,files,opt)
+%finalize. Derive per-file entities and the cross/long split.
+
+  % Natural sort: the longitudinal pipeline relies on the timepoint order,
+  % and a plain alphabetical sort would put ses-10 before ses-2.
+  files = natsortunique(files(:));
+  out.files = files;
+  out.sub   = cell(numel(files),1);
+  out.ses   = cell(numel(files),1);
+
+  for fi = 1:numel(files)
+    ent = parseEntities(files{fi});
+    % keep the full BIDS labels ('sub-01', not '01') so that reports and
+    % dependency names match what the user sees on disk
+    out.sub{fi} = ['sub-' ent.sub];
+    out.ses{fi} = ent.ses;
+  end
+
+  % Session-less data counts as a single session so that a dataset without
+  % any ses-* level is treated as cross-sectional rather than as an error.
+  ses = out.ses;
+  ses(cellfun(@isempty,ses)) = {'_nosession_'};
+
+  [out.subjects,~,subidx] = unique(out.sub,'stable');
+  out.nses          = zeros(numel(out.subjects),1);
+  out.cross         = {};
+  out.long          = {};
+  out.longsubjects  = {};
+  out.longsublabels = {};
+
+  for si = 1:numel(out.subjects)
+    sel  = subidx == si;
+    nses = numel(unique(ses(sel)));
+    out.nses(si) = nses;
+
+    if nses <= 1
+      % <=1 session -> cross-sectional. Note that several runs within one
+      % session are still cross-sectional; the longitudinal pipeline needs
+      % genuinely separate sessions.
+      out.cross = [out.cross; out.files(sel)];
+      if sum(sel) > 1
+        out.missing.multiple_runs_single_session{end+1} = out.subjects{si};
+      end
+    else
+      out.long                    = [out.long; out.files(sel)];
+      out.longsubjects{end+1}     = out.files(sel);
+      out.longsublabels{end+1}    = out.subjects{si};
+    end
+  end
+
+  out.ncross = numel(out.cross);
+  out.nlong  = numel(out.long);
+end
+%==========================================================================
+function files = natsortunique(files)
+%natsortunique. unique() with a natural (human) ordering of digit groups.
+% Every digit group is zero-padded in a temporary sort key only, so that
+% ses-2 sorts before ses-10 as a user would expect.
+
+  files = unique(files);
+  if numel(files) < 2, return; end
+
+  % Built without the ${...} dynamic regexprep expression, which MATLAB
+  % supports but Octave does not.
+  keys = cell(size(files));
+  for i = 1:numel(files)
+    s = files{i};
+    [tok,startix,endix] = regexp(s,'\d+','match','start','end');
+    k = ''; last = 0;
+    for t = 1:numel(tok)
+      k = [k s(last+1:startix(t)-1) sprintf('%012d',str2double(tok{t}))]; %#ok<AGROW>
+      last = endix(t);
+    end
+    keys{i} = [k s(last+1:end)];
+  end
+  [~,idx] = sort(keys);
+  files = files(idx);
+end
+%==========================================================================
+function ent = parseEntities(file)
+%parseEntities. Extract BIDS entities from a filename and its path.
+% The filename is authoritative; the path is only a fallback, because a
+% BIDS filename must carry sub- and ses- itself.
+
+  ent = struct('sub','','ses','','acq','','run','','suffix','');
+
+  [pth,nam] = fileparts(file);
+  [~,nam2]  = fileparts(nam);           % strip the second ext of .nii.gz
+  if ~isempty(nam2), nam = nam2; end
+
+  parts = strsplit(nam,'_');
+  for pi = 1:numel(parts)
+    kv = strsplit(parts{pi},'-');
+    if numel(kv) >= 2
+      key = lower(kv{1});
+      val = strjoin(kv(2:end),'-');
+      if isfield(ent,key), ent.(key) = val; end
+    elseif pi == numel(parts)
+      ent.suffix = parts{pi};            % trailing token without '-' = suffix
+    end
+  end
+
+  % fall back to the directory names if the filename is incomplete
+  if isempty(ent.sub) || isempty(ent.ses)
+    sdirs = strsplit(pth,filesep);
+    for di = numel(sdirs):-1:1
+      d = sdirs{di};
+      if isempty(ent.ses) && strncmpi(d,'ses-',4), ent.ses = d(5:end); end
+      if isempty(ent.sub) && strncmpi(d,'sub-',4), ent.sub = d(5:end); end
+    end
+  end
+end
+%==========================================================================
+function [keep, miss] = filterParticipants(ptsv, expr)
+%filterParticipants. Apply a "column op value" filter to participants.tsv.
+
+  keep = {};
+  miss = struct('unknown_column','','excluded',{{}},'unreadable',false);
+
+  tok = regexp(strtrim(expr),'^(\S+)\s*(==|~=|!=|>=|<=|>|<)\s*(.+)$','tokens','once');
+  if isempty(tok)
+    error('cat_io_BIDSquery:badFilter', ...
+      ['Cannot parse participants filter "%s". ' ...
+       'Expected "column op value", e.g. "group == patient".'], expr);
+  end
+  [col, op, val] = deal(tok{1}, tok{2}, strtrim(tok{3}));
+  if strcmp(op,'!='), op = '~='; end
+
+  T = readTSV(ptsv);
+  if isempty(T), miss.unreadable = true; return; end
+
+  hdr    = T(1,:);
+  idcol  = find(strcmpi(hdr,'participant_id'),1);
+  valcol = find(strcmpi(hdr,col),1);
+  if isempty(idcol),  miss.unknown_column = 'participant_id'; return; end
+  if isempty(valcol), miss.unknown_column = col; return; end
+
+  % == and ~= are always literal string comparisons, even when both sides
+  % happen to parse as numbers. BIDS labels (session_id, run, site, etc.)
+  % are strings by definition and a leading zero is part of the label, e.g.
+  % session_id "01" must NOT equal "1". Only the ordering operators
+  % (>,>=,<,<=), which have no string meaning, use numeric parsing.
+  isOrder = any(strcmp(op,{'>','>=','<','<='}));
+  refnum  = str2double(val);
+  for ri = 2:size(T,1)
+    id   = T{ri,idcol};
+    cell_= T{ri,valcol};
+    if isempty(id), continue; end
+
+    if isOrder
+      cellnum = str2double(cell_);
+      if isnan(refnum) || isnan(cellnum)
+        ok = false;   % ordering is undefined for non-numeric values
+      else
+        ok = compareNum(cellnum, op, refnum);
+      end
+    else
+      ok = compareStr(cell_, op, val);
+    end
+
+    if ok
+      keep{end+1} = id;
+    else
+      miss.excluded{end+1} = id;
+    end
+  end
+end
+%==========================================================================
+function ok = compareNum(a,op,b)
+  switch op
+    case '==', ok = a == b;   case '~=', ok = a ~= b;
+    case '>',  ok = a >  b;   case '>=', ok = a >= b;
+    case '<',  ok = a <  b;   case '<=', ok = a <= b;
+    otherwise, ok = false;
+  end
+end
+%==========================================================================
+function ok = compareStr(a,op,b)
+% Ordering operators are meaningless for strings -> treated as no match.
+  switch op
+    case '==', ok =  strcmpi(strtrim(a),b);
+    case '~=', ok = ~strcmpi(strtrim(a),b);
+    otherwise, ok = false;
+  end
+end
+%==========================================================================
+function T = readTSV(fname)
+%readTSV. Minimal tab-separated reader returning a cell matrix.
+% Deliberately dependency-free (cat_io_csv is comma-oriented) and tolerant
+% of ragged rows, which are common in hand-edited participants.tsv files.
+
+  T = {};
+  fid = fopen(fname,'r');
+  if fid < 0, return; end
+  c = textscan(fid,'%s','Delimiter','\n','Whitespace','');
+  fclose(fid);
+  lines = c{1};
+  lines = lines(~cellfun(@isempty,lines));
+  if isempty(lines), return; end
+
+  % Strip a UTF-8 BOM, which spreadsheet tools (e.g. Excel) commonly add
+  % and which otherwise corrupts the "participant_id" header match.
+  bom = char([239 187 191]);
+  if strncmp(lines{1}, bom, numel(bom))
+    lines{1} = lines{1}(numel(bom)+1:end);
+  end
+
+  rows = cellfun(@(l) strsplit(l,'\t','CollapseDelimiters',false), lines, ...
+    'UniformOutput', false);
+  ncol = max(cellfun(@numel,rows));
+  T    = repmat({''},numel(rows),ncol);
+  for ri = 1:numel(rows)
+    T(ri,1:numel(rows{ri})) = rows{ri};
+  end
+end
+%==========================================================================
+function L = normalizeLabels(L,prefix)
+%normalizeLabels. Accept '01', 'sub-01' and comma separated lists alike.
+
+  if isempty(L), L = {}; return; end
+  if ischar(L), L = strtrim(strsplit(L,',')); end
+  L = cellstr(L);
+  L = L(~cellfun(@isempty,L));
+  for i = 1:numel(L)
+    if ~strncmpi(L{i},prefix,numel(prefix))
+      L{i} = [prefix L{i}];
+    end
+  end
+end
+%==========================================================================
+function r = emptyReport()
+  r = struct( ...
+    'no_dataset_description',      false, ...
+    'no_subject_dirs',             false, ...
+    'no_participants_tsv',         false, ...
+    'tsv_unknown_column',          '', ...
+    'tsv_unreadable',              false, ...
+    'tsv_excluded',                {{}}, ...
+    'tsv_filtered_out',            {{}}, ...
+    'no_anat_dir',                 {{}}, ...
+    'no_matching_file',            {{}}, ...
+    'multiple_runs_single_session',{{}} );
+end

--- a/cat_io_BIDSquery_report.m
+++ b/cat_io_BIDSquery_report.m
@@ -1,0 +1,109 @@
+function cat_io_BIDSquery_report(out, verb)
+%cat_io_BIDSquery_report. Print the result of a cat_io_BIDSquery call.
+%
+% ADD-ON (not part of upstream CAT12). See cat_io_BIDSquery.
+%
+%   cat_io_BIDSquery_report(out [, verb])
+%
+%   out   .. output structure of cat_io_BIDSquery
+%   verb  .. 1-summary (default), 2-list every subject
+%
+% Reports which subjects were found, how the cross-sectional /
+% longitudinal split was made, and - importantly - what was *not* found,
+% so that a silently empty or half-empty selection cannot go unnoticed.
+%
+% See also cat_io_BIDSquery
+% ______________________________________________________________________
+%
+% BIDS input add-on for CAT12 (fork).
+% ______________________________________________________________________
+
+  if nargin < 2, verb = 1; end
+  m = out.missing;
+
+  fprintf('\nCAT12 BIDS input query\n');
+  fprintf('  dataset:      %s\n', out.bidsdir);
+  fprintf('  suffix:       %s\n', strjoin(cellstr(out.opt.suffix),', '));
+  fprintf('  files found:  %d  (%d subjects)\n', numel(out.files), numel(out.subjects));
+  fprintf('  cross-sect.:  %d files  (%d subjects with <=1 session)\n', ...
+    out.ncross, sum(out.nses <= 1));
+  fprintf('  longitudinal: %d files  (%d subjects with >=2 sessions)\n', ...
+    out.nlong, numel(out.longsubjects));
+
+  if verb > 1 && ~isempty(out.subjects)
+    fprintf('\n  subjects:\n');
+    for si = 1:numel(out.subjects)
+      if out.nses(si) <= 1, kind = 'cross'; else, kind = 'long '; end
+      fprintf('    %-20s %s  %d session(s)\n', out.subjects{si}, kind, out.nses(si));
+    end
+  end
+
+  % -- warnings ------------------------------------------------------
+  warned = false;
+
+  if m.no_subject_dirs
+    warned = warn(['No sub-* directories found. Is "%s" really the root of a raw ' ...
+      'BIDS dataset (the directory containing the sub-* folders)?\n'], out.bidsdir);
+  end
+  if m.no_dataset_description
+    warned = warn(['No dataset_description.json in the dataset root. The directory ' ...
+      'may still work, but it is not a valid BIDS dataset.\n']);
+  end
+  if m.no_participants_tsv
+    warned = warn(['A participants filter was requested but no participants.tsv ' ...
+      'exists in the dataset root - the filter was ignored.\n']);
+  end
+  if isfield(m,'tsv_unreadable') && m.tsv_unreadable
+    warned = warn(['participants.tsv could not be read or is empty - the ' ...
+      'filter was ignored.\n']);
+  end
+  if ~isempty(m.tsv_unknown_column)
+    warned = warn(['Column "%s" not found in participants.tsv - the filter was ' ...
+      'ignored.\n'], m.tsv_unknown_column);
+  end
+  warned = listwarn(warned, m.tsv_filtered_out, ...
+    'excluded by the participants.tsv filter');
+  warned = listwarn(warned, m.no_anat_dir, ...
+    'skipped: no anat directory found');
+  warned = listwarn(warned, m.no_matching_file, ...
+    'skipped: anat directory contains no file matching the requested suffix');
+  warned = listwarn(warned, m.multiple_runs_single_session, ...
+    ['has several files within a single session (runs/acquisitions) - ' ...
+     'treated as cross-sectional, NOT longitudinal']);
+
+  if ~warned && ~isempty(out.files)
+    fprintf('  no missing data detected.\n');
+  end
+  fprintf('\n');
+end
+%==========================================================================
+function warned = warn(varargin)
+  cwrite(['  Warning: ' varargin{1}], varargin{2:end});
+  warned = true;
+end
+%==========================================================================
+function cwrite(varargin)
+%cwrite. Coloured output, falling back to fprintf.
+% cat_io_cprintf needs a Java command window and fails e.g. under Octave or
+% with -nodisplay. A warning must never be the thing that aborts the query.
+
+  try
+    cat_io_cprintf('warn', varargin{:});
+  catch
+    fprintf(varargin{:});
+  end
+end
+%==========================================================================
+function warned = listwarn(warned, list, msg)
+%listwarn. Report a list of subjects, truncated to keep the log readable.
+
+  if isempty(list), return; end
+  warned = warn('%d subject(s) %s:\n', numel(list), msg);
+  nshow  = min(numel(list),10);
+  for i = 1:nshow
+    cwrite('    %s\n', list{i});
+  end
+  if numel(list) > nshow
+    cwrite('    ... and %d more\n', numel(list) - nshow);
+  end
+end

--- a/tbx_cfg_cat.m
+++ b/tbx_cfg_cat.m
@@ -114,6 +114,7 @@ opts                = cat_conf_opts(expert);
 [output,output_spm] = cat_conf_output(expert); 
 long                = cat_conf_long;
 factorial_design    = cat_conf_factorial(expert);
+bidsinput           = cat_conf_BIDSinput(expert);  % BIDS input add-on (fork, not upstream)
 
 %% ------------------------------------------------------------------------
 estwrite        = cfg_exbranch;
@@ -153,9 +154,9 @@ cat.tag    = 'cat';
 if exist('cat_conf_catsimple','file')
   [catsimple,catsimple_long] = cat_conf_catsimple(expert);
   catsimple_long.hidden = expert<2;
-  cat.values = {estwrite long catsimple catsimple_long estwrite_spm factorial_design tools stools stoolsexp};
+  cat.values = {bidsinput estwrite long catsimple catsimple_long estwrite_spm factorial_design tools stools stoolsexp};
 else
-  cat.values = {estwrite long estwrite_spm factorial_design tools stools stoolsexp};
+  cat.values = {bidsinput estwrite long estwrite_spm factorial_design tools stools stoolsexp};
 end
 %------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

CAT12 is currently BIDS-aware only on the **output** side: `cat_io_BIDS.m`
infers `sub-`/`ses-`/`anat` entities from paths of files the user already
selected by hand, purely to decide where derivatives are written. There is
no way to point CAT12 at a BIDS dataset root and have it collect input
itself, no entity filtering, and nothing reads `participants.tsv`.

This PR adds that missing input layer as a self-contained add-on, plus one
small output-side addition (`dataset_description.json`) so CAT12
derivatives are themselves valid BIDS-Derivatives datasets.

## What's added

- `cat_io_BIDSquery.m` — query engine: dataset root + filters → file lists,
  with automatic cross-sectional / longitudinal routing (0-1 session →
  cross-sectional, ≥2 sessions → longitudinal, one group per subject).
- `cat_io_BIDSquery_report.m` — reports what was found *and* what was
  skipped (missing anat dirs, non-matching suffixes, tsv-filtered subjects,
  multiple runs in one session, etc.), so an incomplete selection is never
  silent.
- `cat_conf_BIDSinput.m` / `cat_conf_BIDSinput_query.m` /
  `cat_conf_BIDSinput_run.m` — a new SPM batch module, "BIDS: Data
  selection", exposing the query engine via ordinary batch dependencies
  ("BIDS: cross-sectional files", "BIDS: longitudinal `<subject>`", "BIDS:
  all files"), so it plugs into the existing "CAT: Segmentation" and "CAT:
  Longitudinal" modules without modifying either.
- `BIDS_INPUT_ADDON.md` — usage, options, and testing notes.

Filters: participant list, session list, `acq-`/`run-` regexp, and a
`participants.tsv` filter (`"column op value"`, e.g. `group == patient` or
`age >= 18`, with correct string vs. numeric semantics — see below).

## Changes to existing files

Kept intentionally minimal:
